### PR TITLE
Fixing spacing, and adding a second key binding example.

### DIFF
--- a/XMonad/Layout/BinarySpacePartition.hs
+++ b/XMonad/Layout/BinarySpacePartition.hs
@@ -53,6 +53,20 @@ import Control.Monad
 -- > , ((modm,                           xK_r     ), sendMessage Rotate)
 -- > , ((modm,                           xK_s     ), sendMessage Swap)
 --
+-- Here's an alternative key mapping, this time using additionalKeysP,
+-- arrow keys, and slightly different behavior when resizing windows
+--
+-- > , ("M-M1-<Left>",    sendMessage $ ExpandTowards L)
+-- > , ("M-M1-<Right>",   sendMessage $ ShrinkFrom L)
+-- > , ("M-M1-<Up>",      sendMessage $ ExpandTowards U)
+-- > , ("M-M1-<Down>",    sendMessage $ ShrinkFrom U)
+-- > , ("M-M1-C-<Left>",  sendMessage $ ShrinkFrom R)
+-- > , ("M-M1-C-<Right>", sendMessage $ ExpandTowards R)
+-- > , ("M-M1-C-<Up>",    sendMessage $ ShrinkFrom D)
+-- > , ("M-M1-C-<Down>",  sendMessage $ ExpandTowards D)
+-- > , ("M-s",            sendMessage $ BSP.Swap)
+-- > , ("M-M1-s",         sendMessage $ Rotate) ]
+--
 
 -- |Message for rotating a split in the BSP. Keep in mind that this does not change the order
 -- of the windows, it will just turn a horizontal split into a verticial one and vice versa


### PR DESCRIPTION
Hi Ben,

It's a lovely layout that you've put together! It's the staple of my personal xmonad configuration, and it's tremendous help in my day-to-day work. Honestly, with this module, I think XMonad ca put every other WM to shame.

In the beginning, though, I felt it difficult to get my head around the resizing behavior, and this felt quite limiting; at some point I realized that the reason for that was not being able to resize windows upwards. Tonight I finally had time to look into that. Now, I can't say I'm anything else than a Haskell noob, and it'd take me a good while studying your code in order to properly understand how it does its magic, but I followed the general pattern and found where it breaks, so I decided to open a pull request.

The default bindings might look a little alien to someone who expects the second modifier to toggle between top/bottom or left/right border -- rather than between shrinking and expanding. I've added another set of example bindings which implement my preferred behavior -- I assume they could be useful to others.

Cheers,
Adam

EDIT:

> Basically, when you press up, some split will ALWAYS move up, regardless of where the window is.

Hey, that's actually pretty cool in its own right :) Way to go :+1: 

EDIT2: Removed my misconceptions about @SolitaryCipher's new resizing method.
